### PR TITLE
Fix Python environment passed to show command

### DIFF
--- a/poetry_plugin_multiverse/commands/show.py
+++ b/poetry_plugin_multiverse/commands/show.py
@@ -3,11 +3,11 @@ from typing import Optional
 
 from poetry.console.commands import show
 from poetry.puzzle.exceptions import SolverProblemError
-from poetry.utils.env.null_env import NullEnv
 
 from poetry_plugin_multiverse.commands.workspace import WorkspaceCommand
 from poetry_plugin_multiverse.config import WorkspaceConfiguration
 from poetry_plugin_multiverse.repositories import lock, locked_pool
+from poetry_plugin_multiverse.root import root_env
 from poetry_plugin_multiverse.workspace import Workspace
 
 
@@ -46,5 +46,5 @@ class ShowCommand(WorkspaceCommand):
         show_command = show.ShowCommand()
         show_command.set_application(self.application)
         show_command.set_poetry(root)
-        show_command.set_env(NullEnv())
+        show_command.set_env(root_env(root))
         return show_command.run(self.io)

--- a/poetry_plugin_multiverse/repositories.py
+++ b/poetry_plugin_multiverse/repositories.py
@@ -11,8 +11,8 @@ from poetry.poetry import Poetry
 from poetry.repositories.repository import Repository
 from poetry.repositories.repository_pool import Priority, RepositoryPool
 from poetry.utils.env import Env
-from poetry.utils.env.null_env import NullEnv
 
+from poetry_plugin_multiverse.root import root_env
 from poetry_plugin_multiverse.utils import Singleton
 
 
@@ -61,7 +61,7 @@ def create_installer(
 ) -> Installer:
     return Installer(
         io or NullIO(),
-        env or NullEnv(),
+        env or root_env(project),
         project.package,
         project.locker,
         pool,


### PR DESCRIPTION
This PR ensures that the Python version in the environment passed to the show command meets minimum requirement of the workspace. Previously, NullEnv was passed, which defaults to the system environment's version.

Fixes #13 