### PR TITLE
Fix lock with private repositories

### DIFF
--- a/poetry_plugin_multiverse/commands/show.py
+++ b/poetry_plugin_multiverse/commands/show.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Optional
 
 from poetry.console.commands import show
-from poetry.puzzle.exceptions import SolverProblemError
+from poetry.puzzle.provider import IncompatibleConstraintsError
 
 from poetry_plugin_multiverse.commands.workspace import WorkspaceCommand
 from poetry_plugin_multiverse.config import WorkspaceConfiguration
@@ -35,11 +35,11 @@ class ShowCommand(WorkspaceCommand):
 
         root = workspace.root
         try:
-            return_code = lock(root, locked_pool(list(workspace.packages)))
+            return_code = lock(root, locked_pool(*workspace.projects, packages=list(workspace.packages), strict=True))
             if return_code != 0:
                 self.io.write_error_line('<error>Failed to lock workspace!</>')
                 return return_code
-        except SolverProblemError:
+        except IncompatibleConstraintsError:
             self.io.write_error_line('<error>Failed to lock workspace!</>')
             return 1
 

--- a/poetry_plugin_multiverse/hooks/lock.py
+++ b/poetry_plugin_multiverse/hooks/lock.py
@@ -1,15 +1,16 @@
 from contextlib import contextmanager
 from typing import Iterator
+
 from cleo.io.io import IO
 from cleo.io.null_io import NullIO
 from poetry.console.commands.command import Command
 from poetry.console.commands.installer_command import InstallerCommand
-from poetry.console.commands.lock import LockCommand
 from poetry.poetry import Poetry
+from poetry.repositories.repository_pool import Priority
 
 from poetry_plugin_multiverse.cli.progress import progress
 from poetry_plugin_multiverse.hooks.hook import Hook
-from poetry_plugin_multiverse.repositories import create_installer, lock, locked_pool, project_pool, workspace_pool
+from poetry_plugin_multiverse.repositories import create_installer, lock, locked_pool, workspace_pool
 from poetry_plugin_multiverse.workspace import Workspace
 
 
@@ -58,8 +59,9 @@ class PreLockHook(Hook):
             with no_install(io) as lock_io:
                 cmd.execute(NullIO(lock_io.input))
 
-        sources = [] if isinstance(command, LockCommand) else [command.poetry]
-        command.poetry.set_pool(project_pool(*sources, locked=root))
+        command.poetry.set_pool(
+            workspace_pool(command.poetry, locked=root, priority=Priority.EXPLICIT)
+        )
         command.set_installer(create_installer(
             command.poetry,
             command.poetry.pool,

--- a/poetry_plugin_multiverse/packages.py
+++ b/poetry_plugin_multiverse/packages.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from typing import Iterator
 from poetry.core.packages.package import Package
 from poetry.poetry import Poetry
-from poetry.repositories.repository_pool import RepositoryPool
 
 from poetry_plugin_multiverse.dependencies import Record
 
@@ -19,12 +18,8 @@ class Packages:
             for dep in project.locker.locked_repository().packages:
                 deps[dep.complete_name].append(Record(project, dep))
         return Packages(deps)
-    
+
     def __iter__(self) -> Iterator[Package]:
         for record in self.records.values():
             for package in record:
                 yield package.value
-    
-    @property
-    def repository_pool(self) -> RepositoryPool:
-        return RepositoryPool.from_packages(list(self), None)

--- a/poetry_plugin_multiverse/repositories.py
+++ b/poetry_plugin_multiverse/repositories.py
@@ -3,31 +3,85 @@ from typing import Iterator, List, Optional
 
 from cleo.io.io import IO
 from cleo.io.null_io import NullIO
+from poetry.core.constraints.version import Version
+from poetry.core.packages.dependency import Dependency
 from poetry.core.packages.package import Package
+from poetry.core.packages.utils.link import Link
 from poetry.installation.installer import Installer
 from poetry.poetry import Poetry
-from poetry.repositories.repository_pool import Priority, RepositoryPool
+from poetry.repositories.repository import Repository
+from poetry.repositories.repository_pool import RepositoryPool
 from poetry.utils.env import Env
 
 from poetry_plugin_multiverse.root import root_env
 from poetry_plugin_multiverse.utils import Singleton
 
 
-def locked_pool(packages: List[Package]) -> RepositoryPool:
-    return RepositoryPool.from_packages(packages, None)
+def repo_packages(upstream: Repository, packages: List[Package]) -> Iterator[Package]:
+    for package in packages:
+        if package.source_reference in { None, upstream.name }:
+            yield package
 
 
-def workspace_pool(*projects: Poetry, locked: Optional[Poetry] = None, priority: Optional[Priority] = None) -> RepositoryPool:
-    pool = RepositoryPool([locked.locker.locked_repository()] if locked else [])
+class LockedRepository(Repository):
+    def __init__(self, upstream: Repository, packages: List[Package], *, strict: bool) -> None:
+        super().__init__(upstream.name, list(repo_packages(upstream, packages)))
+        self.upstream = upstream
+        self.strict = strict
+    
+    def find_packages(self, dependency: Dependency) -> List[Package]:
+        if locked := super().find_packages(dependency):
+            return locked
+        if not self.strict:
+            return self.upstream.find_packages(dependency)
+        return []
+    
+    def has_package(self, package: Package) -> bool:
+        if super().has_package(package):
+            return True
+        if not self.strict:
+            return self.upstream.has_package(package)
+        return False
+    
+    def search(self, query: str) -> List[Package]:
+        if locked := super().search(query):
+            return locked
+        if not self.strict:
+            return self.upstream.search(query)
+        return []
+    
+    def find_links_for_package(self, package: Package) -> List[Link]:
+        return self.upstream.find_links_for_package(package)
+    
+    def package(self, name: str, version: Version, extras: Optional[List[str]] = None) -> Package:
+        return self.upstream.package(name, version, extras)
 
-    min_priority = priority or (Priority.SECONDARY if locked else Priority.DEFAULT)
+
+def non_empty_pools(*projects: Poetry) -> Iterator[RepositoryPool]:
     for poetry in projects:
-        for repo in poetry.pool.all_repositories:
-            priority = max(poetry.pool.get_priority(repo.name), min_priority)
+        if len(poetry.pool.all_repositories) > 0:
+            yield poetry.pool
+
+
+def locked_pool(*projects: Poetry, packages: List[Package], strict: bool) -> RepositoryPool:
+    pool = RepositoryPool()
+
+    pools = list(non_empty_pools(*projects)) or [
+        RepositoryPool.from_packages(packages, config=None)
+    ]
+
+    for project_pool in pools:
+        for repo in project_pool.all_repositories:
+            priority = project_pool.get_priority(repo.name)
             if not pool.has_repository(repo.name):
-                pool.add_repository(repo, priority=priority)
+                locked = LockedRepository(repo, packages, strict=strict)
+                pool.add_repository(locked, priority=priority)
 
     return pool
+
+
+def workspace_pool(*projects: Poetry) -> RepositoryPool:
+    return locked_pool(*projects, packages=[], strict=False)
 
 
 def create_installer(

--- a/poetry_plugin_multiverse/root.py
+++ b/poetry_plugin_multiverse/root.py
@@ -14,8 +14,6 @@ from poetry.utils.env.base_env import Env
 from poetry.utils.env.mock_env import MockEnv
 from poetry.utils.env.null_env import NullEnv
 
-from poetry_plugin_multiverse.dependencies import Dependencies
-
 
 def root_project(*projects: Poetry, path: Path) -> Poetry:
     aggregate_project = ProjectPackage('workspace', '0.0.0')
@@ -26,8 +24,9 @@ def root_project(*projects: Poetry, path: Path) -> Poetry:
         py_versions = py_versions.intersect(project.package.python_constraint)
     aggregate_project.python_versions = str(py_versions)
 
-    for dep in Dependencies.from_projects(*projects):
-        aggregate_project.add_dependency(dep)
+    for project in projects:
+        for dep in project.package.all_requires:
+            aggregate_project.add_dependency(dep)
 
     pyproject = path / 'workspace.toml'
     pyproject.write_text(Factory.create_pyproject_from_package(aggregate_project).as_string())

--- a/tests/commands/test_lock.py
+++ b/tests/commands/test_lock.py
@@ -4,7 +4,7 @@ from tests.conftest import ProjectFactory
 from tests.utils import command
 from tests import utils
 from poetry.core.packages.package import Package
-from poetry.puzzle.exceptions import SolverProblemError
+from poetry.puzzle.provider import IncompatibleConstraintsError
 
 
 def test_dependencies_conflict(project: ProjectFactory):
@@ -17,16 +17,16 @@ def test_dependencies_conflict(project: ProjectFactory):
 
     project.workspace(p1)
     lock = command(p1, LockCommand)
-    with pytest.raises(SolverProblemError):
+    with pytest.raises(IncompatibleConstraintsError):
         lock.execute()
 
 
 def test_align_versions(project: ProjectFactory):
     project.packages(Package('click', '8.0.9'))
-    p2 = utils.add(project('p2'), 'click=^8')
+    p2 = utils.add(project('p2'), 'click=^8', '--source=mock')
 
     project.packages(Package('click', '8.1.2'))
-    p1 = utils.add(project('p1'), 'click=^8.1')
+    p1 = utils.add(project('p1'), 'click=^8.1', '--source=mock')
 
     project.packages(Package('click', '8.1.4'))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from typing import Iterator, Mapping, Optional
 
 from poetry.core.packages.package import Package
 from poetry.poetry import Poetry
-from poetry.repositories import Repository, RepositoryPool
+from poetry.repositories import RepositoryPool
 import pytest
 
 from poetry_plugin_multiverse.config import MultiverseToml, WorkspaceConfiguration
@@ -62,5 +62,5 @@ def working_dir(path: Path) -> Iterator[Path]:
 @pytest.fixture
 def project(tmp_path: Path) -> Iterator[ProjectFactory]:
     with working_dir(tmp_path):
-        with PoolFactory().override(RepositoryPool([Repository('mock')])) as pool:
+        with PoolFactory().override(RepositoryPool([utils.TestRepository('mock')])) as pool:
             yield ProjectFactory(tmp_path, pool)

--- a/tests/test_packages.py
+++ b/tests/test_packages.py
@@ -21,21 +21,3 @@ def test_packages_multiple(project: ProjectFactory):
         Package('click', '8.0.9'),
         Package('click', '8.1.2')
     }
-
-
-def test_packages_pool(project: ProjectFactory):
-    project.packages(
-        Package('click', '8.0.9')
-    )
-    p2 = utils.add(project('p2'), 'click=^8')
-
-    project.packages(
-        Package('click', '8.1.2')
-    )
-    p1 = utils.add(project('p1'), 'click=^8.1')
-
-    pool = Packages.from_projects(p1, p2).repository_pool
-    assert set(pool.search('click')) == {
-        Package('click', '8.0.9'),
-        Package('click', '8.1.2')
-    }

--- a/tests/test_repositories.py
+++ b/tests/test_repositories.py
@@ -1,5 +1,4 @@
 from poetry.core.packages.package import Package
-from poetry.repositories.repository_pool import Priority
 from poetry.utils.env import NullEnv
 
 from poetry_plugin_multiverse.repositories import lock, locked_pool, workspace_pool
@@ -7,8 +6,8 @@ from tests import utils
 from tests.conftest import ProjectFactory
 
 
-def test_locked_pool():
-    pool = locked_pool([Package('click', '8.1.2')])
+def test_locked_pool(project: ProjectFactory):
+    pool = locked_pool(project('p1'), packages=[Package('click', '8.1.2')], strict=True)
     assert pool.search('click') == [
         Package('click', '8.1.2')
     ]
@@ -40,7 +39,7 @@ def test_workspace_pool_locked(project: ProjectFactory):
 
     project.packages(Package('click', '8.1.4'))
 
-    pool = workspace_pool(p1, p2, locked=p2, priority=Priority.EXPLICIT)
+    pool = locked_pool(p1, p2, packages=p2.locker.locked_repository().packages, strict=True)
     assert pool.search('click') == [
         Package('click', '8.1.2')
     ]
@@ -50,7 +49,7 @@ def test_project_pool_urls(project: ProjectFactory):
     project.packages(Package('click', '8.1.2'))
     p2 = utils.add(project('p2'), 'click=^8.1')
 
-    pool = workspace_pool(p2, locked=p2, priority=Priority.EXPLICIT)
+    pool = locked_pool(p2, packages=p2.locker.locked_repository().packages, strict=True)
     links = pool.repository('mock').find_links_for_package(pool.search('click')[0])
     assert len(links) > 0
 
@@ -62,7 +61,7 @@ def test_lock(project: ProjectFactory):
     project.packages(Package('click', '8.1.2'))
     project.packages(Package('click', '8.1.4'))
 
-    pool = locked_pool([Package('click', '8.1.2')])
+    pool = locked_pool(p1, packages=[Package('click', '8.1.2')], strict=True)
     assert lock(p1, pool, env=NullEnv()) == 0
     assert p1.locker.locked_repository().search('click') == [
         Package('click', '8.1.2')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,10 +12,19 @@ from poetry.console.commands.command import Command
 from poetry.console.commands.env_command import EnvCommand
 from poetry.console.commands.installer_command import InstallerCommand
 from poetry.console.commands.self.self_command import SelfCommand
+from poetry.core.packages.package import Package
+from poetry.core.packages.utils.link import Link
 from poetry.factory import Factory
 from poetry.poetry import Poetry
-from poetry.repositories import RepositoryPool
+from poetry.repositories import Repository, RepositoryPool
 from poetry.utils.env.mock_env import MockEnv
+
+
+class TestRepository(Repository):
+    def find_links_for_package(self, package: Package) -> List[Link]:
+        package_name = package.name.replace('-', '_')
+        wheel = f'{package_name}-{package.version.to_string()}-py3-none-any.whl'
+        return [Link(f'https://null.irregular-expressions.net/simple/{wheel}')]
 
 
 def set_env(command: CleoCommand):


### PR DESCRIPTION
This PR ensures that named repositories are in the pool provided to the workspace lock command and the lock hook. Previously, packages were stored in a single repository, which prevented Poetry from resolving links to locked packages.

Fixes #15 